### PR TITLE
gp4prog: Include <cstdlib>

### DIFF
--- a/src/gp4prog/main.cpp
+++ b/src/gp4prog/main.cpp
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA                                      *
  **********************************************************************************************************************/
 
+#include <cstdlib>
 #include <cstring>
 #include <cmath>
 #include <unistd.h>


### PR DESCRIPTION
Some functions used here (e.g. atoi) are supposed to live in <cstdlib>.
Fixes build on macOS.